### PR TITLE
Keyfile fixes

### DIFF
--- a/libdesktop-agnostic/config-client.vala
+++ b/libdesktop-agnostic/config-client.vala
@@ -73,7 +73,7 @@ namespace DesktopAgnostic.Config
       }
       construct
       {
-        if (value != null && !this.create_instance_config (value))
+        if (value != null &&  this._schema != null && !this.create_instance_config (value))
         {
           warning ("The configuration schema has declared that there can only be a single configuration instance.");
           warning ("Not creating an instance config object.");
@@ -133,6 +133,11 @@ namespace DesktopAgnostic.Config
     private bool
     create_instance_config (string instance_id) throws GLib.Error
     {
+      if (this._schema == null)
+      {
+        return false;
+      }
+
       Value? single_instance = this._schema.get_metadata_option ("single_instance");
       if ((single_instance != null) && (single_instance.get_boolean()) )
       {

--- a/libdesktop-agnostic/config-impl-gconf.vala
+++ b/libdesktop-agnostic/config-impl-gconf.vala
@@ -256,7 +256,7 @@ namespace DesktopAgnostic.Config
       {
         vt = GConf.ValueType.LIST;
       }
-      else if (this.schema.find_type (type) != null)
+      else if (Schema.find_type (type) != null)
       {
         vt = GConf.ValueType.STRING;
       }
@@ -310,7 +310,7 @@ namespace DesktopAgnostic.Config
       }
       else
       {
-        SchemaType st = this.schema.find_type (type);
+        SchemaType st = Schema.find_type (type);
         if (st == null)
         {
           throw new Error.INVALID_TYPE ("Invalid config value type.");
@@ -349,7 +349,7 @@ namespace DesktopAgnostic.Config
         }
         else
         {
-          SchemaType st = this.schema.find_type (type);
+          SchemaType st = Schema.find_type (type);
           if (st == null)
           {
             throw new Error.INVALID_TYPE ("Invalid config value type: %s.",

--- a/libdesktop-agnostic/config.vala
+++ b/libdesktop-agnostic/config.vala
@@ -168,7 +168,7 @@ namespace DesktopAgnostic.Config
       }
       else
       {
-        SchemaType st = schema.find_type (option_type);
+        SchemaType st = Schema.find_type (option_type);
         if (st == null)
         {
           throw new Error.INVALID_TYPE ("Invalid config value type.");

--- a/libdesktop-agnostic/ui-icon-chooser-dialog.vala
+++ b/libdesktop-agnostic/ui-icon-chooser-dialog.vala
@@ -98,7 +98,7 @@ namespace DesktopAgnostic.UI
     {
       this.response.connect (this.on_response);
       this.title = _ ("Select Icon");
-      this.icon_name = STOCK_FIND;
+      this.icon_name = Gtk.Stock.FIND;
       this.set_default_size (375, 375);
       this.create_ui ();
     }
@@ -121,8 +121,8 @@ namespace DesktopAgnostic.UI
 
       this.on_icon_type_toggled ();
 
-      this.add_buttons (STOCK_CANCEL, ResponseType.CANCEL,
-                        STOCK_OK, ResponseType.OK);
+      this.add_buttons (Gtk.Stock.CANCEL, ResponseType.CANCEL,
+                        Gtk.Stock.OK, ResponseType.OK);
     }
 
     private void

--- a/libdesktop-agnostic/ui-launcher-editor-dialog.vala
+++ b/libdesktop-agnostic/ui-launcher-editor-dialog.vala
@@ -113,8 +113,8 @@ namespace DesktopAgnostic.UI
       bool is_application = true;
 
       // Action bar
-      this.add_buttons (STOCK_CANCEL, ResponseType.CANCEL,
-                        STOCK_SAVE, ResponseType.APPLY);
+      this.add_buttons (Gtk.Stock.CANCEL, ResponseType.CANCEL,
+                        Gtk.Stock.SAVE, ResponseType.APPLY);
       this.set_default_response (ResponseType.CANCEL);
       this.response.connect (this.on_response);
 
@@ -133,7 +133,7 @@ namespace DesktopAgnostic.UI
       }
       else
       {
-        icon = STOCK_MISSING_IMAGE;
+        icon = Gtk.Stock.MISSING_IMAGE;
       }
       this._icon = new IconButton (icon);
       this._icon.icon_selected.connect (this.on_icon_changed);
@@ -219,7 +219,7 @@ namespace DesktopAgnostic.UI
       this._exec.changed.connect (this.on_exec_changed);
       exec_hbox.pack_start (this._exec, true);
       exec_button = new Button.with_mnemonic (_ ("_Browse..."));
-      exec_image = new Image.from_stock (STOCK_OPEN, IconSize.BUTTON);
+      exec_image = new Image.from_stock (Gtk.Stock.OPEN, IconSize.BUTTON);
       exec_button.set_image (exec_image);
       exec_button.clicked.connect (this.on_exec_browse);
       exec_hbox.pack_start (exec_button, false);
@@ -325,8 +325,8 @@ namespace DesktopAgnostic.UI
 
       dialog = new FileChooserDialog (title, this,
                                       FileChooserAction.OPEN,
-                                      STOCK_CANCEL, ResponseType.CANCEL,
-                                      STOCK_OK, ResponseType.OK);
+                                      Gtk.Stock.CANCEL, ResponseType.CANCEL,
+                                      Gtk.Stock.OK, ResponseType.OK);
       response = dialog.run ();
       if (response == ResponseType.OK)
       {
@@ -359,8 +359,8 @@ namespace DesktopAgnostic.UI
 
       dialog = new FileChooserDialog (_ ("Save As"), this,
                                       FileChooserAction.SAVE,
-                                      STOCK_CANCEL, ResponseType.CANCEL,
-                                      STOCK_SAVE_AS, ResponseType.ACCEPT);
+                                      Gtk.Stock.CANCEL, ResponseType.CANCEL,
+                                      Gtk.Stock.SAVE_AS, ResponseType.ACCEPT);
       response = dialog.run ();
       if (response == ResponseType.ACCEPT)
       {

--- a/libdesktop-agnostic/vfs-file-impl-gio.vala
+++ b/libdesktop-agnostic/vfs-file-impl-gio.vala
@@ -175,25 +175,30 @@ namespace DesktopAgnostic.VFS
       return new FileMonitorGIO (this);
     }
     public override bool
-    load_contents (out string contents, out size_t length) throws Error
+    load_contents (out string contents, out size_t length)
     {
-      uint8 [] glib_contents;
-      if (this._file.load_contents (null, out glib_contents, null))
+      try
       {
+        uint8 [] glib_contents;
+        this._file.load_contents (null, out glib_contents, null);
         contents = (string)(owned)glib_contents;
         length = contents.length;
         return true;
       }
-      else
+      catch (GLib.Error e)
       {
+        warning ("Failed to load the file '%s': %s Code:%d",
+                  this._file.get_parse_name (), e.message, e.code);
+        contents = "";
+        length = 0;
         return false;
       }
     }
     public override bool
     replace_contents (string contents) throws Error
     {
-      return this._file.replace_contents (contents.data, null,
-                                          false, 0, null, null);
+      return this._file.replace_contents (contents.data, null, false,
+                                          FileCreateFlags.NONE, null, null);
     }
     public override bool
     launch () throws Error

--- a/wscript
+++ b/wscript
@@ -94,9 +94,11 @@ def configure(conf):
     conf.env['VNUM'] = str(VNUM)
 
     conf.check_tool('gnu_dirs')
-    conf.check_tool('compiler_cc intltool misc python vala')
+    conf.check_tool('compiler_cc misc python vala')
+    try: conf.check_tool('intltool')
+    except: pass
 
-    MIN_VALA_VERSION = (0, 10, 0)
+    MIN_VALA_VERSION = (0, 16, 0)
 
     conf.check_cfg(package='gmodule-2.0', uselib_store='GMODULE',
                    atleast_version='2.6.0', mandatory=True,


### PR DESCRIPTION
Hi:

I was testing awn in Debian sid and fixed various issues with the Keyfile backend. It now works with awn w/o too many issues. The keyfile backend works great but too avoid ~5-6 applets having a file monitor on avant-window-navigator.ini it would be better if gconf just got ported to gsettings. The FileMonitor thing is not that big of an issue really but it was out of hand before.

The explanations are in the commit headers or in the code. I also fixed  https://bugs.launchpad.net/awn/+bug/990774 but that requires a PR for awn which I will do later it's a 2 liner but awn has other issues. I have not tested awn-extras yet.

Notes:
You might consider removing
>CFLAGS += -O0

from the Makefile since I could not reproduce the segmentation fault listed in the known issues file.

Also, I saw that you have a RFP in debian so it would probably be a good idea to just remove the gnome backend for desktop entries since since it requires a deprecated library (libgnome-desktop-2-17) and it was the one of the reasons that got it removed from jessie. The functionality used in the backend got removed from the library. The upgrade path given by upstream is to either use GDesktopAppInfo or keyfiles. The gio/glib backend already use the Keyfile approach so it could be safely removed.

Also updating the 2 lines in the wscript to transition from libgladeui-1-9 to  libglade2 which makes it compile with glade2 but I don't use glade so I'm not sure if something got silently broken. Glade1 also got removed from Debian but it seems it was a drop in replacement in this case.

FinalIy, I  have an updated debian packaging in my github that is the one I use (well after I push the ~40 commits I have).

Hope this helps.